### PR TITLE
Facilitate porting of Evil-DICOM to Portable Class Library

### DIFF
--- a/EvilDICOM.Core/EvilDICOM.Core/DICOMObject.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/DICOMObject.cs
@@ -245,9 +245,8 @@ namespace EvilDICOM.Core
         /// <returns>a list of all elements that meet the search criteria</returns>
         public List<IDICOMElement> FindAll(Tag[] descendingTags)
         {
-            var stringList = new List<string>();
-            descendingTags.ToList().ForEach(t => stringList.Add(t.CompleteID));
-            return FindAll(stringList.ToArray());
+            var strings = descendingTags.Select(t => t.CompleteID).ToArray();
+            return FindAll(strings);
         }
 
         /// <summary>

--- a/EvilDICOM.Core/EvilDICOM.Core/DICOMObject.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/DICOMObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using EvilDICOM.Core.Element;
@@ -169,7 +170,7 @@ namespace EvilDICOM.Core
         public List<T> FindAll<T>()
         {
             Type t = typeof (T);
-            return AllElements.Where(el => el is T).Select(el => (T) Convert.ChangeType(el, t)).ToList();
+            return AllElements.Where(el => el is T).Select(el => (T) Convert.ChangeType(el, t, CultureInfo.CurrentCulture)).ToList();
         }
 
         /// <summary>

--- a/EvilDICOM.Core/EvilDICOM.Core/Dictionaries/TagDictionary.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/Dictionaries/TagDictionary.cs
@@ -3682,9 +3682,9 @@ namespace EvilDICOM.Core.Dictionaries
         /// <returns>a string description of the tag in camel case</returns>
         public static string GetDescription(string completeId)
         {
-            var element = new string(completeId.Skip(4).Take(4).ToArray());
+            var element = completeId.Substring(4, 4);
             return element == GROUP_HEADER
-                ? string.Format("Group header for group {0}", new string(completeId.Take(4).ToArray()))
+                ? string.Format("Group header for group {0}", completeId.Substring(0, 4))
                 : Tags.ContainsKey(completeId)
                     ? Tags[completeId].Description
                     : "Unknown Tag";

--- a/EvilDICOM.Core/EvilDICOM.Core/Element/Tag.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/Element/Tag.cs
@@ -63,6 +63,11 @@ namespace EvilDICOM.Core.Element
             return false;
         }
 
+        public override int GetHashCode()
+        {
+            return this.CompleteID.GetHashCode();
+        }
+
         public static bool operator ==(Tag t1, Tag t2)
         {
             if ((object)t1 == null) return false;

--- a/EvilDICOM.Core/EvilDICOM.Core/Helpers/Constants.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/Helpers/Constants.cs
@@ -5,7 +5,7 @@ namespace EvilDICOM.Core.Helpers
     public static class Constants
     {
         public static string EVIL_DICOM_IMP_UID = "1.2.598.0.1.2851334.2.1865.1";
-        public static string EVIL_DICOM_IMP_VERSION = Assembly.GetCallingAssembly().GetName().Version.ToString();
+        public static string EVIL_DICOM_IMP_VERSION = new AssemblyName(Assembly.GetCallingAssembly().FullName).Version.ToString();
         //APPLICATION CONTEXT
         public static string DEFAULT_APPLICATION_CONTEXT = "1.2.840.10008.3.1.1.1";
     }

--- a/EvilDICOM.Core/EvilDICOM.Core/Helpers/EnumHelper.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/Helpers/EnumHelper.cs
@@ -6,7 +6,7 @@ namespace EvilDICOM.Core.Helpers
     {
         public static T StringToEnum<T>(string name)
         {
-            return (T) Enum.Parse(typeof (T), name);
+            return (T) Enum.Parse(typeof (T), name, false);
         }
     }
 }

--- a/EvilDICOM.Core/EvilDICOM.Core/IO/Data/DICOMString.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/IO/Data/DICOMString.cs
@@ -6,13 +6,13 @@ namespace EvilDICOM.Core.IO.Data
     {
         public static string Read(byte[] data)
         {
-            var enc = new ASCIIEncoding();
+            var enc = Encoding.UTF8;
             return enc.GetString(data).TrimEnd(new[] {'\0'}).TrimEnd(new[] {' '});
         }
 
         public static byte[] Write(string data)
         {
-            var ascii = new ASCIIEncoding();
+            var ascii = Encoding.UTF8;
 
             if (IsEven(data))
             {
@@ -26,7 +26,7 @@ namespace EvilDICOM.Core.IO.Data
             return data.Length%2 == 0;
         }
 
-        private static byte[] PadOddBytes(ASCIIEncoding ascii, string data)
+        private static byte[] PadOddBytes(Encoding ascii, string data)
         {
             return ascii.GetBytes(data + '\0');
         }

--- a/EvilDICOM.Core/EvilDICOM.Core/IO/Data/DataComposer.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/IO/Data/DataComposer.cs
@@ -175,7 +175,7 @@ namespace EvilDICOM.Core.IO.Data
         {
             if (!string.IsNullOrEmpty(s))
             {
-                return new ASCIIEncoding().GetBytes(s);
+                return Encoding.UTF8.GetBytes(s);
             }
             return new byte[0];
         }

--- a/EvilDICOM.Core/EvilDICOM.Core/IO/Data/DataRestriction.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/IO/Data/DataRestriction.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using EvilDICOM.Core.Enums;
+using EvilDICOM.Core.Logging;
 
 namespace EvilDICOM.Core.IO.Data
 {
@@ -9,7 +10,7 @@ namespace EvilDICOM.Core.IO.Data
         {
             if (data.Length > lengthLimit)
             {
-                Console.Write(
+                EvilLogger.Instance.Log(
                     "Not DICOM compliant. Attempted data input of {0} characters. Data size is limited to {1} characters. Read anyway.",
                     data.Length, lengthLimit);
                 return data;

--- a/EvilDICOM.Core/EvilDICOM.Core/IO/Reading/DICOMBinaryReader.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/IO/Reading/DICOMBinaryReader.cs
@@ -61,7 +61,7 @@ namespace EvilDICOM.Core.IO.Reading
 
         public void Dispose()
         {
-            _binaryReader.Close();
+            _binaryReader.Dispose();
         }
 
         /// <summary>

--- a/EvilDICOM.Core/EvilDICOM.Core/IO/Reading/DICOMBinaryReader.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/IO/Reading/DICOMBinaryReader.cs
@@ -29,7 +29,7 @@ namespace EvilDICOM.Core.IO.Reading
         {
             _binaryReader = new BinaryReader(
                 new FileStream(filePath, FileMode.Open, FileAccess.Read),
-                new ASCIIEncoding());
+                Encoding.UTF8);
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace EvilDICOM.Core.IO.Reading
         public DICOMBinaryReader(byte[] byteStream)
         {
             _binaryReader = new BinaryReader(new MemoryStream(byteStream),
-                new ASCIIEncoding());
+                Encoding.UTF8);
         }
 
         /// <summary>

--- a/EvilDICOM.Core/EvilDICOM.Core/IO/Writing/DICOMBinaryWriter.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/IO/Writing/DICOMBinaryWriter.cs
@@ -46,7 +46,7 @@ namespace EvilDICOM.Core.IO.Writing
 
         public void Write(string chars)
         {
-            char[] asCharArray = chars.ToCharArray(0, chars.Length);
+            char[] asCharArray = chars.ToCharArray();
             Write(asCharArray);
         }
 

--- a/EvilDICOM.Core/EvilDICOM.Core/IO/Writing/DICOMBinaryWriter.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/IO/Writing/DICOMBinaryWriter.cs
@@ -26,7 +26,7 @@ namespace EvilDICOM.Core.IO.Writing
 
         public void Dispose()
         {
-            _writer.Close();
+            _writer.Dispose();
         }
 
         public void Write(byte b)

--- a/EvilDICOM.Core/EvilDICOM.Core/IO/Writing/DICOMBinaryWriter.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/IO/Writing/DICOMBinaryWriter.cs
@@ -16,12 +16,12 @@ namespace EvilDICOM.Core.IO.Writing
         {
             _writer = new BinaryWriter(
                 File.Open(filePath, FileMode.Create),
-                new ASCIIEncoding());
+                Encoding.UTF8);
         }
 
         public DICOMBinaryWriter(Stream stream)
         {
-            _writer = new BinaryWriter(stream, new ASCIIEncoding());
+            _writer = new BinaryWriter(stream, Encoding.UTF8);
         }
 
         public void Dispose()


### PR DESCRIPTION
Hi Rex,

As I think you know, I am trying to maintain a Portable Class Library fork of *Evil-DICOM* under the *Cureos* account. Only practical difference between your .NET version and the PCL version is that the PCL version uses `Stream` instead of file name arguments in the reader and writer classes.

Porting to PCL has so far worked well, since the *Evil-DICOM* code is overall very portable. However, there are a few parts of your original code that do not immediately compile under PCL. To facilitate continued porting to PCL, I have therefore collected fixes to these incompatibilities in a pull request.

Please note that the fork from which I am making this pull request is **not** the PCL fork, but a .NET fork from your latest commit created solely to support this pull request. There are **no** changes to the API included, and the changes should be functionally equivalent to the original code.

I hope you approve of this proposal. Please feel free to pull in the entire request or cherry pick some of the commits. And if you don't approve, simply ignore the request.

Best regards,
Anders @ Cureos