### PR TITLE
Improve memory efficiency and performance

### DIFF
--- a/EvilDICOM.Core/EvilDICOM.Core/IO/Reading/DICOMBinaryReader.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/IO/Reading/DICOMBinaryReader.cs
@@ -10,7 +10,7 @@ namespace EvilDICOM.Core.IO.Reading
     /// </summary>
     public class DICOMBinaryReader : IDisposable
     {
-        #region PRIVATE
+        #region PROTECTED
 
         protected BinaryReader _binaryReader;
 
@@ -73,7 +73,13 @@ namespace EvilDICOM.Core.IO.Reading
         {
             var buffer = new byte[count];
             int read = _binaryReader.Read(buffer, 0, count);
-            return buffer.Take(read).ToArray();
+
+            if (read < count)
+            {
+                Array.Resize(ref buffer, read);
+            }
+
+            return buffer;
         }
 
         /// <summary>
@@ -116,7 +122,13 @@ namespace EvilDICOM.Core.IO.Reading
         {
             var buffer = new char[count];
             int read = _binaryReader.Read(buffer, 0, count);
-            return buffer.Take(read).ToArray();
+
+            if (read < count)
+            {
+                Array.Resize(ref buffer, read);
+            }
+
+            return buffer;
         }
 
         /// <summary>
@@ -126,9 +138,7 @@ namespace EvilDICOM.Core.IO.Reading
         /// <returns>the read chars</returns>
         public virtual string ReadString(int length)
         {
-            var buffer = new char[length];
-            int read = _binaryReader.Read(buffer, 0, length);
-            return new string(buffer.Take(read).ToArray());
+            return new string(ReadChars(length));
         }
 
         public int ReadBytes(byte[] buffer, int index, int count)
@@ -138,7 +148,14 @@ namespace EvilDICOM.Core.IO.Reading
 
         public virtual DICOMBinaryReader Skip(int count)
         {
-            ReadBytes(count);
+            if (_binaryReader.BaseStream.CanSeek)
+            {
+                _binaryReader.BaseStream.Seek(count, System.IO.SeekOrigin.Current);
+            }
+            else
+            {
+                ReadBytes(count);
+            }
             return this;
         }
 


### PR DESCRIPTION
These changes greatly decreases memory required when reading in large pixel data elements.

The repeated "buffer.Take(read).ToArray()" ends up creating an excessive amount of smaller arrays as it scales up its backing buffer (the TakeIterator prevents the usual optimizations).
I need to process the meta data for a large amount of DICOM volumes but skipping over the pixel data element still needed about 200MB of memory for 40MB of pixel data and regrettably caused OutOfMemoryExceptions when bulk processing.

A Visual Studio 2015 diagnostic comparison: http://imgur.com/a/2OL1b