### PR TITLE
Fixed internationalization issues when writing numbers with separators.

### DIFF
--- a/EvilDICOM.Core/EvilDICOM.Core.Tests/DataTests.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core.Tests/DataTests.cs
@@ -7,6 +7,9 @@ using E=EvilDICOM.Core.Element;
 using System.Linq;
 using EvilDICOM.Core.Element;
 using EvilDICOM.Core.Enums;
+using EvilDICOM.Core.IO.Data;
+using System.Globalization;
+using System.Threading;
 
 namespace EvilDICOM.Core.Tests
 {
@@ -52,6 +55,58 @@ namespace EvilDICOM.Core.Tests
             var x = xyz[0];
             var y = xyz[1];
             var z = xyz[2];
+        }
+
+        [TestMethod]
+        public void StringDataComposer_ComposeDateTime_HasCorrectSeparator()
+        {
+            var dateTime = new System.DateTime(621671364610101010, DateTimeKind.Unspecified);
+
+            var currentThread = Thread.CurrentThread;
+            var currentCulture = currentThread.CurrentCulture;
+
+            currentThread.CurrentCulture = CreateNonDotSeparatorCulture();
+
+            try
+            {
+                var actual = StringDataComposer.ComposeDateTime(dateTime);
+                var expected = "19710101010101.010101";
+                Assert.AreEqual(expected, actual);
+            }
+            finally
+            {
+                currentThread.CurrentCulture = currentCulture;
+            }
+        }
+
+        [TestMethod]
+        public void StringDataComposer_ComposeDecimalString_HasCorrectSeparator()
+        {
+            var data = new[] { -2.5, 5, 7.5 };
+
+            var currentThread = Thread.CurrentThread;
+            var currentCulture = currentThread.CurrentCulture;
+
+            currentThread.CurrentCulture = CreateNonDotSeparatorCulture();
+
+            try
+            {
+                var actual = StringDataComposer.ComposeDecimalString(data);
+                var expected = @"-2.5\5\7.5";
+                Assert.AreEqual(expected, actual);
+            }
+            finally
+            {
+                currentThread.CurrentCulture = currentCulture;
+            }
+        }
+
+        private static CultureInfo CreateNonDotSeparatorCulture()
+        {
+            var nonDotSeparatorCulture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            nonDotSeparatorCulture.NumberFormat.NumberGroupSeparator = "@";
+            nonDotSeparatorCulture.NumberFormat.NumberDecimalSeparator = "*";
+            return nonDotSeparatorCulture;
         }
     }
 }

--- a/EvilDICOM.Core/EvilDICOM.Core.Tests/DecimalStringTests.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core.Tests/DecimalStringTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using EvilDICOM.Core.Element;
 using EvilDICOM.Core.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
+using System.Threading;
 
 namespace EvilDICOM.Core.Tests
 {
@@ -82,11 +84,51 @@ namespace EvilDICOM.Core.Tests
         }
 
         [TestMethod]
-        public void ToString_VerifyOutput()
+        public void ToString_VerifyOutput_CurrentCultureInsensitive_AreNotEqual()
         {
             const string expected = "(300A,0082) : BeamDoseSpecificationPoint (DecimalString) -> 1 | -3.5 | 2.5";
-            var actual = _decimalString.ToString();
-            Assert.AreEqual(expected, actual);
+            var currentThread = Thread.CurrentThread;
+            var currentCulture = currentThread.CurrentCulture;
+
+            currentThread.CurrentCulture = CreateNonDotSeparatorCulture();
+
+            try
+            {
+                var actual = _decimalString.ToString();
+                Assert.AreNotEqual(expected, actual);
+            }
+            finally
+            {
+                currentThread.CurrentCulture = currentCulture;
+            }
+        }
+
+        [TestMethod]
+        public void ToString_VerifyOutput_CurrentCultureSensitive_AreEqual()
+        {
+            const string expected = "(300A,0082) : BeamDoseSpecificationPoint (DecimalString) -> 1 | -3*5 | 2*5";
+            var currentThread = Thread.CurrentThread;
+            var currentCulture = currentThread.CurrentCulture;
+
+            currentThread.CurrentCulture = CreateNonDotSeparatorCulture();
+
+            try
+            {
+                var actual = _decimalString.ToString();
+                Assert.AreEqual(expected, actual);
+            }
+            finally
+            {
+                currentThread.CurrentCulture = currentCulture;
+            }
+        }
+
+        private static CultureInfo CreateNonDotSeparatorCulture()
+        {
+            var nonDotSeparatorCulture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            nonDotSeparatorCulture.NumberFormat.NumberGroupSeparator = "@";
+            nonDotSeparatorCulture.NumberFormat.NumberDecimalSeparator = "*";
+            return nonDotSeparatorCulture;
         }
 
         #endregion

--- a/EvilDICOM.Core/EvilDICOM.Core/IO/Data/StringDataComposer.cs
+++ b/EvilDICOM.Core/EvilDICOM.Core/IO/Data/StringDataComposer.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using EvilDICOM.Core.Element;
 using DateTime = System.DateTime;
+using System.Globalization;
 
 namespace EvilDICOM.Core.IO.Data
 {
@@ -11,7 +12,7 @@ namespace EvilDICOM.Core.IO.Data
         {
             if (data != null)
             {
-                string ageString = String.Format("{0:00#}", data.Number);
+                string ageString = String.Format(CultureInfo.InvariantCulture, "{0:00#}", data.Number);
                 switch (data.Units)
                 {
                     case Age.Unit.DAYS:
@@ -37,7 +38,7 @@ namespace EvilDICOM.Core.IO.Data
             if (data != null)
             {
                 var date = (DateTime) data;
-                return date.ToString("yyyyMMdd");
+                return date.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
             }
             return string.Empty;
         }
@@ -47,7 +48,7 @@ namespace EvilDICOM.Core.IO.Data
             if (data != null)
             {
                 var date = (DateTime) data;
-                return date.ToString("yyyyMMddHHmmss.ffffff");
+                return date.ToString("yyyyMMddHHmmss.ffffff", CultureInfo.InvariantCulture);
             }
             return string.Empty;
         }
@@ -56,7 +57,7 @@ namespace EvilDICOM.Core.IO.Data
         {
             if (data != null)
             {
-                return String.Join("\\", data.Select(d => d.ToString()).ToArray());
+                return String.Join("\\", data.Select(d => d.ToString(CultureInfo.InvariantCulture)).ToArray());
             }
             return string.Empty;
         }
@@ -65,7 +66,7 @@ namespace EvilDICOM.Core.IO.Data
         {
             if (data != null)
             {
-                return String.Join("\\", data.Select(d => d.ToString()).ToArray());
+                return String.Join("\\", data.Select(d => d.ToString(CultureInfo.InvariantCulture)).ToArray());
             }
             return string.Empty;
         }
@@ -75,7 +76,7 @@ namespace EvilDICOM.Core.IO.Data
             if (data != null)
             {
                 var date = (DateTime) data;
-                return date.ToString("HHmmss.ffffff");
+                return date.ToString("HHmmss.ffffff", CultureInfo.InvariantCulture);
             }
             return string.Empty;
         }


### PR DESCRIPTION
Decimal Strings were written with the CurrentCulture decimal separator resulting in invalid decimal strings in some cultures.

Added some additional test to catch these issues going forward.