### PR TITLE
Bug when using big endian transfer syntax

### DIFF
--- a/EvilDICOM/EvilDICOM/Core/IO/Writing/LengthWriter.cs
+++ b/EvilDICOM/EvilDICOM/Core/IO/Writing/LengthWriter.cs
@@ -24,11 +24,6 @@ namespace EvilDICOM.Core.IO.Writing
 
         public static void Write(DICOMBinaryWriter dw, VR vr, DICOMWriteSettings settings, int length)
         {
-            if (settings.TransferSyntax == TransferSyntax.IMPLICIT_VR_LITTLE_ENDIAN)
-            {
-                return;
-            }
-
             var lengthBytes = new byte[0];
             switch (VRDictionary.GetEncodingFromVR(vr))
             {

--- a/EvilDICOM/EvilDICOM/Core/IO/Writing/LengthWriter.cs
+++ b/EvilDICOM/EvilDICOM/Core/IO/Writing/LengthWriter.cs
@@ -24,38 +24,32 @@ namespace EvilDICOM.Core.IO.Writing
 
         public static void Write(DICOMBinaryWriter dw, VR vr, DICOMWriteSettings settings, int length)
         {
-            var lengthBytes = new byte[0];
-            if (!(settings.TransferSyntax == TransferSyntax.IMPLICIT_VR_LITTLE_ENDIAN))
+            if (settings.TransferSyntax == TransferSyntax.IMPLICIT_VR_LITTLE_ENDIAN)
             {
-                switch (VRDictionary.GetEncodingFromVR(vr))
-                {
-                    case VREncoding.ExplicitLong:
-                        dw.WriteNullBytes(2);
-                        lengthBytes = BitConverter.GetBytes(length);
-                        break;
-                    case VREncoding.ExplicitShort:
-                        lengthBytes = BitConverter.GetBytes((ushort) length);
-                        break;
-                    case VREncoding.Implicit:
-                        lengthBytes = BitConverter.GetBytes(length);
-                        break;
-                }
+                return;
             }
-            else if (settings.TransferSyntax == TransferSyntax.EXPLICIT_VR_BIG_ENDIAN)
-            {
-                lengthBytes = BitConverter.GetBytes(length);
-                lengthBytes.Reverse();
-            }
-            else
-            {
-                //Explicit VR Little Endian
-                lengthBytes = BitConverter.GetBytes(length);
-            }
-            dw.Write(lengthBytes);
-        }
 
-        public static void WriteBigEndian(DICOMBinaryWriter dw, VR vr, int length)
-        {
+            var lengthBytes = new byte[0];
+            switch (VRDictionary.GetEncodingFromVR(vr))
+            {
+                case VREncoding.ExplicitLong:
+                    dw.WriteNullBytes(2);
+                    lengthBytes = BitConverter.GetBytes(length);
+                    break;
+                case VREncoding.ExplicitShort:
+                    lengthBytes = BitConverter.GetBytes((ushort)length);
+                    break;
+                case VREncoding.Implicit:
+                    lengthBytes = BitConverter.GetBytes(length);
+                    break;
+            }
+
+            if (settings.TransferSyntax == TransferSyntax.EXPLICIT_VR_BIG_ENDIAN)
+            {
+                Array.Reverse(lengthBytes);
+            }
+
+            dw.Write(lengthBytes);
         }
 
         public static void WriteBigEndian(DICOMBinaryWriter dw, int length, int numberOfBytes)
@@ -64,12 +58,13 @@ namespace EvilDICOM.Core.IO.Writing
             switch (numberOfBytes)
             {
                 case 2:
-                    lengthBytes = BitConverter.GetBytes((ushort) length).Reverse().ToArray();
+                    lengthBytes = BitConverter.GetBytes((ushort) length);
                     break;
                 case 4:
-                    lengthBytes = BitConverter.GetBytes(length).Reverse().ToArray();
+                    lengthBytes = BitConverter.GetBytes(length);
                     break;
             }
+            Array.Reverse(lengthBytes);
             dw.Write(lengthBytes);
         }
     }


### PR DESCRIPTION
When writing big endian lengths the bytes were not reversed.

```csharp
var pathToDicom = @"...";
var dicom = DICOMFileReader.Read(pathToDicom);
var bigEndian = new DICOMWriteSettings
{
    TransferSyntax = TransferSyntax.EXPLICIT_VR_BIG_ENDIAN
};
DICOMFileWriter.Write(pathToDicom, bigEndian, dicom);
```

Also removed the unused `WriteBigEndian` stub and switched from `Enumerable.Reverse` to the more efficient `Array.Reverse`.