### PR TITLE
Fix : Characters may not render properly due to UTF8 being unexpectedly returned from `EncodingDictionary`

### DIFF
--- a/EvilDICOM/EvilDICOM/Core/Dictionaries/EncodingDictionary.cs
+++ b/EvilDICOM/EvilDICOM/Core/Dictionaries/EncodingDictionary.cs
@@ -39,7 +39,7 @@ namespace EvilDICOM.Core.Dictionaries
 
         public static Encoding GetEncodingFromISO(string isoStandard)
         {
-            var iso = isoStandard.Replace("_", string.Empty).ToUpper();
+            var iso = isoStandard.Replace("_", " ").ToUpper();
             if (encodingMap.ContainsKey(iso)) { return Encoding.GetEncoding(encodingMap[iso]); }
             else return Encoding.UTF8;
         }


### PR DESCRIPTION
**BACKGROUND**

When working with the `Evil-DICOM` library you **might** find that "special characters" are not rendering properly.  This commit addresses the fact that the `GetEncodingFromISO()` method may return UTF-8 unexpectedly.

**EXAMPLE**

1. calling: `GetEncodingFromISO("ISO_IR_100")`
2. generated the following key: `ISOIR100`
3. because `ISOIR100` does not exist in the dictionary (`ISO IR 100` does exist), `Encoding.UTF8` was returned


**RELATED ISSUES**

This bug _may_ partly explain these issues:
- [Specific Character Set support.](https://github.com/rexcardan/Evil-DICOM/issues/30)
- [Special Characters in string](https://github.com/rexcardan/Evil-DICOM/issues/24)
