### PR TITLE
Update CFindImageIOD.cs

### DIFF
--- a/EvilDICOM/EvilDICOM/Network/DIMSE/IOD/CFindImageIOD.cs
+++ b/EvilDICOM/EvilDICOM/Network/DIMSE/IOD/CFindImageIOD.cs
@@ -20,6 +20,9 @@ namespace EvilDICOM.Network.DIMSE.IOD
             PatientsName = DF.Patient​Name();
             StudyInstanceUID = string.Empty;
             SeriesInstanceUID = string.Empty;
+            AcquisitionDate = null;
+            ContentDate = null;
+            Modality = string.Empty;
         }
 
         public CFindImageIOD(DICOMObject dcm) : base(dcm)
@@ -66,5 +69,24 @@ namespace EvilDICOM.Network.DIMSE.IOD
             get { return _sel.SOP​Instance​UID != null ? _sel.SOP​Instance​UID.Data : null; }
             set { _sel.Forge(DF.SOP​Instance​UID(value)); }
         }
+        
+        public S.DateTime? AcquisitionDate
+        {
+          get { return _sel.AcquisitionDate != null ? _sel.AcquisitionDate.Data : null; }
+          set { _sel.Forge(DF.AcquisitionDate(value)); }
+        }
+
+        public S.DateTime? Content​Date
+        {
+          get { return _sel.Content​Date != null ? _sel.Content​Date.Data : null; }
+          set { _sel.Forge(DF.Content​Date(value)); }
+        }
+
+        public string Modality
+        {
+          get { return _sel.Modality != null ? _sel.Modality.Data : null; }
+          set { _sel.Forge(DF.Modality(value)); }
+        }
+        
     }
 }


### PR DESCRIPTION
The  AcquisitionDate, ContentDate, and Modality are useful to pull images by date (even series because I don't know why I getting the SeriesDate atribute always empty after using CFindSeriesIOD see issue).

These attributes are very important because sometimes a patient can get two fractions of treatment in a single day (morning and afternoon). So, The AcquisitionDate and ContentDate are very useful to differentiate those images when pulling.

I hope it makes sense.